### PR TITLE
gettext .po support

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -79,8 +79,8 @@ Author: Neil Sanchala
     <!-- Java compilation. -->
     <javac srcdir="${java.src.dir}:${build.genfiles.dir}"
            destdir="${build.classes.dir}"
-           source="1.7"
-           target="1.7"
+           source="1.8"
+           target="1.8"
            includeAntRuntime="true"
            debug="${includeDebugInfo}">
       <classpath refid="classpath.path" />
@@ -652,8 +652,8 @@ Author: Neil Sanchala
     <mkdir dir="${build.testclasses.dir}" />
     <javac srcdir="${java.tests.dir}"
            destdir="${build.testclasses.dir}"
-           source="1.7"
-           target="1.7"
+           source="1.8"
+           target="1.8"
            includeAntRuntime="false"
            debug="${includeDebugInfo}">
       <classpath refid="classpath.path" />

--- a/build.xml
+++ b/build.xml
@@ -130,8 +130,6 @@ Author: Neil Sanchala
       <zipgroupfileset dir="${java.lib.dir}">
         <include name="aopalliance.jar" />
         <include name="args4j*.jar" />
-        <include name="guava*.jar" />
-        <include name="icu4j*.jar" />
         <include name="javax.inject.jar" />
         <include name="jsr305.jar" />
       </zipgroupfileset>

--- a/java/src/com/google/template/soy/pomsgplugin/PoException.java
+++ b/java/src/com/google/template/soy/pomsgplugin/PoException.java
@@ -1,0 +1,17 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.google.template.soy.pomsgplugin;
+
+/**
+ *
+ * @author Stephen Searles <stephen@leapingbrain.com>
+ */
+public class PoException extends RuntimeException {
+
+  public PoException(String message) {
+    super(message);
+  }
+
+}

--- a/java/src/com/google/template/soy/pomsgplugin/PoGenerator.java
+++ b/java/src/com/google/template/soy/pomsgplugin/PoGenerator.java
@@ -1,0 +1,192 @@
+package com.google.template.soy.pomsgplugin;
+
+import com.google.template.soy.internal.base.Pair;
+import com.google.template.soy.msgs.SoyMsgBundle;
+import com.google.template.soy.msgs.restricted.SoyMsg;
+import com.google.template.soy.msgs.restricted.SoyMsgPart;
+import com.google.template.soy.msgs.restricted.SoyMsgPlaceholderPart;
+import com.google.template.soy.msgs.restricted.SoyMsgPluralCaseSpec;
+import com.google.template.soy.msgs.restricted.SoyMsgRawTextPart;
+import com.google.template.soy.msgs.restricted.SoyMsgPluralPart;
+import com.google.template.soy.msgs.restricted.SoyMsgSelectPart;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+/**
+ * Generates gettext-format PO files from SoyMsgBundles.
+ *
+ * See http://www.gnu.org/software/gettext/manual/html_node/PO-Files.html
+ *
+ * @author Stephen Searles <stephen@leapingbrain.com>
+ */
+public class PoGenerator {
+
+   private PoGenerator() {}
+
+
+  /**
+   * Generates the output PO file content for a given SoyMsgBundle.
+   *
+   * @param msgBundle The SoyMsgBundle to process.
+   * @param sourceLocaleString The source language/locale string of the messages.
+   * @param targetLocaleString The target language/locale string of the messages (optional). If
+   *     specified, the resulting PO file will specify this target language and will contain
+   *     empty 'target' tags. If not specified, the resulting PO file will not contain target
+   *     language and will not contain 'target' tags.
+   * @return The generated PO file content.
+   */
+  static CharSequence generatePo(
+      SoyMsgBundle msgBundle,
+      String sourceLocaleString,
+      @Nullable String targetLocaleString) {
+
+    StringBuilder poBuilder = new StringBuilder();
+
+    for (SoyMsg msg : msgBundle) {
+      poBuilder.append(generateMessage(msg));
+    }
+
+    return poBuilder;
+  }
+
+  /**
+   * Generate an individual message
+   */
+  private static String generateMessage(SoyMsg msg) {
+    StringBuilder msgBuilder = new StringBuilder();
+    String meaning = msg.getMeaning();
+    if (meaning != null && meaning.length() > 0) {
+      msgBuilder.append("# Meaning: ").append(meaning).append("\n");
+    }
+
+    msgBuilder.append("#: id=").append(msg.getId()).append("\n");
+    msgBuilder.append("#: type=").append(msg.getContentType()).append("\n");
+
+    SoyMsgPart firstPart = msg.getParts().get(0);
+    if (firstPart instanceof SoyMsgPluralPart && msg.getParts().size() > 1) {
+      throw new PoException(
+              "No message content is allowed before or after a "
+              + "plural block. Found: " + msg.getParts().get(1).toString());
+    } else if (firstPart instanceof SoyMsgPluralPart) {
+      msgBuilder.append(generatePluralVar((SoyMsgPluralPart)firstPart));
+      msgBuilder.append(generateDescription(msg));
+      msgBuilder.append(generatePluralMessage((SoyMsgPluralPart)firstPart));
+    } else {
+      msgBuilder.append(generateDescription(msg));
+      msgBuilder.append("msgid \"");
+      msgBuilder.append(generateSingularMessage(msg));
+      msgBuilder.append("\"\n");
+    }
+
+    // Add an empty translation
+    msgBuilder.append("msgstr \"\"\n\n");
+    return msgBuilder.toString();
+  }
+
+  /**
+   * Generate a non-plural message.
+   *
+   * @throws PoException Thrown when a plural block is found.
+   */
+  private static String generateSingularMessage(SoyMsg msg) {
+    StringBuilder msgBuilder = new StringBuilder();
+    for (SoyMsgPart msgPart : msg.getParts()) {
+      if (msgPart instanceof SoyMsgPluralPart) {
+        throw new PoException("No message content is allowed before or after a "
+                + "plural block. Found: " + msgPart);
+      }
+      msgBuilder.append(message(msgPart));
+    }
+    return msgBuilder.toString();
+  }
+
+  /**
+   * Generate a comment line designating the variable controlling pluralization.
+   *
+   * E.g. => #: pluralVar=NUM_ITEMS_1
+   *
+   * The syntax of this line is a use of the PO automatic comments feature to
+   * pass on the plural variable that will be parsed and used by the
+   * SoyToJsSrcCompiler and the Closure Compiler when inserting translated
+   * messages into usable source code.
+   *
+   */
+  private static String generatePluralVar(SoyMsgPluralPart pluralPart) {
+    return "#: pluralVar=" + pluralPart.getPluralVarName() + "\n";
+  }
+
+  /**
+   * Generate a description line.
+   *
+   * Returns an empty string if the message has no description.
+   */
+  private static String generateDescription(SoyMsg msg) {
+    String desc = msg.getDesc();
+    if (desc != null && desc.length() > 0) {
+      return "msgctxt \"" + desc + "\"\n";
+    }
+    return "";
+  }
+
+  /**
+   * Extracts a message from a SoyMsgPart into PO format.
+   *
+   * Newlines and backslashes are escaped.
+   * This method does not handle {plural} or {select}.
+   *
+   */
+  static String message(SoyMsgPart msgPart) {
+    if (msgPart instanceof SoyMsgRawTextPart) {
+      return escapeString(((SoyMsgRawTextPart) msgPart).getRawText());
+    } else if (msgPart instanceof SoyMsgPluralPart) {
+      throw new PoException("PO generation does not support embedded {plural}."
+              + " {plural} must wrap entire message.");
+    } else if (msgPart instanceof SoyMsgSelectPart) {
+      throw new PoException("PO generation does not support {select}.");
+    } else if (msgPart instanceof SoyMsgPlaceholderPart) {
+      String placeholderName =
+              ((SoyMsgPlaceholderPart) msgPart).getPlaceholderName();
+      return "{$" + placeholderName + "}";
+    } else {
+      throw new PoException("Unexpected message part type: " + msgPart);
+    }
+  }
+
+  static String escapeString(String s) {
+    return s.replace("\"", "\\\"").replace("\n","\\n\"\n\"");
+  }
+
+  /**
+   * Extracts the PO style plural message from the SoyMsgPluralPart.
+   * @throws PoException
+   */
+  static String generatePluralMessage(SoyMsgPluralPart msgPart)
+          throws PoException {
+    StringBuilder msgBuilder = new StringBuilder();
+
+    for (Pair<SoyMsgPluralCaseSpec, List<SoyMsgPart>> pluralPart :
+            msgPart.getCases()) {
+
+      if (pluralPart.first.getType() == SoyMsgPluralCaseSpec.Type.EXPLICIT &&
+          pluralPart.first.getExplicitValue() == 1) {
+        msgBuilder.append("msgid \"");
+        for (SoyMsgPart pluralSubPart : pluralPart.second) {
+            msgBuilder.append(message(pluralSubPart));
+        }
+        msgBuilder.append("\"\n");
+      } else if (pluralPart.first.getType() == SoyMsgPluralCaseSpec.Type.OTHER) {
+        msgBuilder.append("msgid_plural \"");
+        for (SoyMsgPart pluralSubPart : pluralPart.second) {
+          msgBuilder.append(message(pluralSubPart));
+        }
+        msgBuilder.append("\"\n");
+      } else {
+        throw new PoException("PO only supports explicit 1 and N variants,"
+                + " {case 1} and {default}, respectively.");
+      }
+    }
+    return msgBuilder.toString();
+  }
+
+}

--- a/java/src/com/google/template/soy/pomsgplugin/PoGenerator.java
+++ b/java/src/com/google/template/soy/pomsgplugin/PoGenerator.java
@@ -9,6 +9,9 @@ import com.google.template.soy.msgs.restricted.SoyMsgPluralCaseSpec;
 import com.google.template.soy.msgs.restricted.SoyMsgRawTextPart;
 import com.google.template.soy.msgs.restricted.SoyMsgPluralPart;
 import com.google.template.soy.msgs.restricted.SoyMsgSelectPart;
+
+import com.google.common.collect.ImmutableList;
+
 import java.util.List;
 
 import javax.annotation.Nullable;
@@ -160,13 +163,9 @@ public class PoGenerator {
    * Extracts the PO style plural message from the SoyMsgPluralPart.
    * @throws PoException
    */
-  static String generatePluralMessage(SoyMsgPluralPart msgPart)
-          throws PoException {
+  static String generatePluralMessage(SoyMsgPluralPart msgPart) throws PoException {
     StringBuilder msgBuilder = new StringBuilder();
-
-    for (Pair<SoyMsgPluralCaseSpec, List<SoyMsgPart>> pluralPart :
-            msgPart.getCases()) {
-
+    for (Pair<SoyMsgPluralCaseSpec, ImmutableList<SoyMsgPart>> pluralPart : msgPart.getCases()) {
       if (pluralPart.first.getType() == SoyMsgPluralCaseSpec.Type.EXPLICIT &&
           pluralPart.first.getExplicitValue() == 1) {
         msgBuilder.append("msgid \"");

--- a/java/src/com/google/template/soy/pomsgplugin/PoGenerator.java
+++ b/java/src/com/google/template/soy/pomsgplugin/PoGenerator.java
@@ -55,13 +55,12 @@ public class PoGenerator {
    */
   private static String generateMessage(SoyMsg msg) {
     StringBuilder msgBuilder = new StringBuilder();
-    String meaning = msg.getMeaning();
-    if (meaning != null && meaning.length() > 0) {
-      msgBuilder.append("# Meaning: ").append(meaning).append("\n");
+    String desc = msg.getDesc();
+    if (desc != null && desc.length() > 0) {
+      msgBuilder.append("#. ").append(desc).append("\n");
     }
 
     msgBuilder.append("#: id=").append(msg.getId()).append("\n");
-    msgBuilder.append("#: type=").append(msg.getContentType()).append("\n");
 
     SoyMsgPart firstPart = msg.getParts().get(0);
     if (firstPart instanceof SoyMsgPluralPart && msg.getParts().size() > 1) {
@@ -70,10 +69,10 @@ public class PoGenerator {
               + "plural block. Found: " + msg.getParts().get(1).toString());
     } else if (firstPart instanceof SoyMsgPluralPart) {
       msgBuilder.append(generatePluralVar((SoyMsgPluralPart)firstPart));
-      msgBuilder.append(generateDescription(msg));
+      msgBuilder.append(generateCtxt(msg));
       msgBuilder.append(generatePluralMessage((SoyMsgPluralPart)firstPart));
     } else {
-      msgBuilder.append(generateDescription(msg));
+      msgBuilder.append(generateCtxt(msg));
       msgBuilder.append("msgid \"");
       msgBuilder.append(generateSingularMessage(msg));
       msgBuilder.append("\"\n");
@@ -121,8 +120,8 @@ public class PoGenerator {
    *
    * Returns an empty string if the message has no description.
    */
-  private static String generateDescription(SoyMsg msg) {
-    String desc = msg.getDesc();
+  private static String generateCtxt(SoyMsg msg) {
+    String desc = msg.getMeaning();
     if (desc != null && desc.length() > 0) {
       return "msgctxt \"" + desc + "\"\n";
     }
@@ -147,7 +146,7 @@ public class PoGenerator {
     } else if (msgPart instanceof SoyMsgPlaceholderPart) {
       String placeholderName =
               ((SoyMsgPlaceholderPart) msgPart).getPlaceholderName();
-      return "{$" + placeholderName + "}";
+      return "{" + placeholderName + "}";
     } else {
       throw new PoException("Unexpected message part type: " + msgPart);
     }

--- a/java/src/com/google/template/soy/pomsgplugin/PoMsgPlugin.java
+++ b/java/src/com/google/template/soy/pomsgplugin/PoMsgPlugin.java
@@ -1,0 +1,45 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.google.template.soy.pomsgplugin;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.template.soy.msgs.SoyMsgBundle;
+import com.google.template.soy.msgs.SoyMsgBundleHandler.OutputFileOptions;
+import com.google.template.soy.msgs.SoyMsgException;
+import com.google.template.soy.msgs.SoyMsgPlugin;
+
+/**
+ *
+ * @author Stephen Searles <stephen@leapingbrain.com>
+ */
+
+@Singleton
+public class PoMsgPlugin implements SoyMsgPlugin {
+
+  @Inject
+  public PoMsgPlugin() {}
+
+
+  @Override public CharSequence generateExtractedMsgsFile(
+      SoyMsgBundle msgBundle, OutputFileOptions options)
+      throws SoyMsgException {
+
+    return PoGenerator.generatePo(
+        msgBundle, options.getSourceLocaleString(), options.getTargetLocaleString());
+  }
+
+
+  @Override public SoyMsgBundle parseTranslatedMsgsFile(String inputFileContent)
+      throws SoyMsgException {
+
+    try {
+      return PoParser.parsePoTargetMsgs(inputFileContent);
+    } catch (PoException e) {
+      throw new SoyMsgException(e);
+    }
+  }
+
+}

--- a/java/src/com/google/template/soy/pomsgplugin/PoMsgPluginModule.java
+++ b/java/src/com/google/template/soy/pomsgplugin/PoMsgPluginModule.java
@@ -1,0 +1,21 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.google.template.soy.pomsgplugin;
+
+import com.google.inject.AbstractModule;
+import com.google.template.soy.msgs.SoyMsgPlugin;
+
+/**
+ * Guice module to bind the PoMsgPlugin.
+ *
+ * @author Stephen Searles <stephen@leapingbrain.com>
+ */
+public class PoMsgPluginModule extends AbstractModule {
+
+  @Override protected void configure() {
+
+    bind(SoyMsgPlugin.class).to(PoMsgPlugin.class);
+  }
+}

--- a/java/src/com/google/template/soy/pomsgplugin/PoParser.java
+++ b/java/src/com/google/template/soy/pomsgplugin/PoParser.java
@@ -1,0 +1,158 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.google.template.soy.pomsgplugin;
+
+import com.google.template.soy.internal.base.Pair;
+import com.google.template.soy.msgs.SoyMsgBundle;
+import com.google.template.soy.msgs.SoyMsgException;
+import com.google.template.soy.msgs.restricted.SoyMsg;
+import com.google.template.soy.msgs.restricted.SoyMsgBundleImpl;
+import com.google.template.soy.msgs.restricted.SoyMsgPart;
+import com.google.template.soy.msgs.restricted.SoyMsgPlaceholderPart;
+import com.google.template.soy.msgs.restricted.SoyMsgPluralCaseSpec;
+import com.google.template.soy.msgs.restricted.SoyMsgPluralPart;
+import com.google.template.soy.msgs.restricted.SoyMsgRawTextPart;
+
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.InputMismatchException;
+import java.util.Scanner;
+import java.util.regex.Pattern;
+
+/**
+ *
+ * @author Stephen Searles <stephen@leapingbrain.com>
+ */
+public class PoParser {
+
+  private PoParser() {}
+
+  /**
+   * Parses the content of a translated XLIFF file and creates a SoyMsgBundle.
+   *
+   * @param poContent The PO content to parse.
+   * @return The resulting SoyMsgBundle.
+   * @throws PoException If there's an error parsing the data.
+   * @throws SoyMsgException If there's an error in parsing the data.
+   */
+  static SoyMsgBundle parsePoTargetMsgs(String poContent) {
+    ArrayList messages = new ArrayList<SoyMsg>();
+
+    Scanner scanner = new Scanner(poContent);
+    scanner.useDelimiter("\n\n");
+
+    while (scanner.hasNext()) {
+      messages.add(parseMessage(scanner.next()));
+    }
+
+    return new SoyMsgBundleImpl("xx", messages);
+  }
+
+  private static SoyMsg parseMessage(String messageContent) {
+
+    long id = 0;
+    String locale = "xx";
+    ArrayList<SoyMsgPart> parts = new ArrayList<SoyMsgPart>();
+    boolean isPlural = false;
+    String meaning = null;
+    String desc = null;
+
+    Scanner scanner = new Scanner(messageContent);
+
+    StringBuilder pluralTranslationLines = new StringBuilder();
+
+    while (scanner.hasNextLine()) {
+      String line = scanner.nextLine();
+      if (line.startsWith("#: id=")) {
+        String idString = line.substring(6);
+        id = Long.parseLong(idString);
+      } else if (line.startsWith("msgid_plural")) {
+        isPlural = true;
+      } else if (line.startsWith("msgstr ")) {
+        parseTranslationLine(line, parts);
+      } else if (line.startsWith("msgstr[")) {
+        pluralTranslationLines.append(line);
+        pluralTranslationLines.append("\n");
+      }
+    }
+
+    if (isPlural) {
+      if (parts.size() > 0) {
+        throw new PoException("Cannot mix plural and non-pluralized translations.");
+      }
+      parts.add(parsePluralTranslation(pluralTranslationLines.toString()));
+    }
+
+    return new SoyMsg(id, -1L, locale, meaning, desc, false, null, null, isPlural, parts);
+  }
+
+  private static SoyMsgPluralPart parsePluralTranslation(String translationLines) {
+
+    ArrayList<Pair<SoyMsgPluralCaseSpec, List<SoyMsgPart>>> cases;
+    cases = new ArrayList<Pair<SoyMsgPluralCaseSpec, List<SoyMsgPart>>>();
+
+    Scanner scanner = new Scanner(translationLines);
+    scanner.useDelimiter("\n");
+
+    while (scanner.hasNext()) {
+      cases.add(parsePluralTranslationLine(scanner.nextLine()));
+    }
+
+    return new SoyMsgPluralPart("varName", 0, cases);
+  }
+
+  private static void parseTranslationLine(String translationLine, ArrayList<SoyMsgPart> parts) {
+    Scanner scanner = new Scanner(translationLine);
+    scanner.useDelimiter("'|\"");
+
+    scanner.next();
+    parseTranslationString(scanner.next(), parts);
+  }
+
+  private static void parseTranslationString(String translationString, ArrayList<SoyMsgPart> parts) {
+    Scanner scanner = new Scanner(translationString);
+    scanner.useDelimiter(Pattern.compile("\\{\\$|\\}"));
+    boolean inVariableToken = false;
+
+    while (scanner.hasNext()) {
+      if (inVariableToken) {
+        parts.add(new SoyMsgPlaceholderPart(scanner.next()));
+      } else {
+        parts.add(new SoyMsgRawTextPart(scanner.next()));
+      }
+      inVariableToken = !inVariableToken;
+    }
+
+    if (scanner.hasNextLine()) {
+      String remainder = scanner.nextLine();
+      if (remainder.length() > 0) {
+        parts.add(new SoyMsgRawTextPart(remainder));
+      }
+    }
+  }
+
+  private static Pair<SoyMsgPluralCaseSpec, List<SoyMsgPart>> parsePluralTranslationLine(String translationLine) {
+    int n;
+    Scanner scanner = new Scanner(translationLine);
+    scanner.useDelimiter("\\[|\\]");
+    try {
+      scanner.next();
+    } catch (InputMismatchException e) {
+      throw new PoException("Incorrect plural translation line: ".concat(translationLine));
+    }
+    n = scanner.nextInt();
+    SoyMsgPluralCaseSpec caseSpec = new SoyMsgPluralCaseSpec(n);
+    ArrayList<SoyMsgPart> parts = new ArrayList<SoyMsgPart>();
+
+    parseTranslationLine(scanner.nextLine(), parts);
+
+    return new Pair<SoyMsgPluralCaseSpec, List<SoyMsgPart>>(caseSpec, parts);
+
+  }
+
+
+
+}

--- a/java/src/com/google/template/soy/pomsgplugin/PoParser.java
+++ b/java/src/com/google/template/soy/pomsgplugin/PoParser.java
@@ -15,6 +15,7 @@ import com.google.template.soy.msgs.restricted.SoyMsgPluralCaseSpec;
 import com.google.template.soy.msgs.restricted.SoyMsgPluralPart;
 import com.google.template.soy.msgs.restricted.SoyMsgRawTextPart;
 
+import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.ArrayList;
@@ -91,8 +92,8 @@ public class PoParser {
 
   private static SoyMsgPluralPart parsePluralTranslation(String translationLines) {
 
-    ArrayList<Pair<SoyMsgPluralCaseSpec, List<SoyMsgPart>>> cases;
-    cases = new ArrayList<Pair<SoyMsgPluralCaseSpec, List<SoyMsgPart>>>();
+    ArrayList<Pair<SoyMsgPluralCaseSpec, ImmutableList<SoyMsgPart>>> cases
+        = new ArrayList<Pair<SoyMsgPluralCaseSpec, ImmutableList<SoyMsgPart>>>();
 
     Scanner scanner = new Scanner(translationLines);
     scanner.useDelimiter("\n");
@@ -101,7 +102,7 @@ public class PoParser {
       cases.add(parsePluralTranslationLine(scanner.nextLine()));
     }
 
-    return new SoyMsgPluralPart("varName", 0, cases);
+    return new SoyMsgPluralPart("varName", 0, ImmutableList.copyOf(cases));
   }
 
   private static void parseTranslationLine(String translationLine, ArrayList<SoyMsgPart> parts) {
@@ -121,7 +122,7 @@ public class PoParser {
       if (inVariableToken) {
         parts.add(new SoyMsgPlaceholderPart(scanner.next()));
       } else {
-        parts.add(new SoyMsgRawTextPart(scanner.next()));
+        parts.add(SoyMsgRawTextPart.of(scanner.next()));
       }
       inVariableToken = !inVariableToken;
     }
@@ -129,12 +130,12 @@ public class PoParser {
     if (scanner.hasNextLine()) {
       String remainder = scanner.nextLine();
       if (remainder.length() > 0) {
-        parts.add(new SoyMsgRawTextPart(remainder));
+        parts.add(SoyMsgRawTextPart.of(remainder));
       }
     }
   }
 
-  private static Pair<SoyMsgPluralCaseSpec, List<SoyMsgPart>> parsePluralTranslationLine(String translationLine) {
+  private static Pair<SoyMsgPluralCaseSpec, ImmutableList<SoyMsgPart>> parsePluralTranslationLine(String translationLine) {
     int n;
     Scanner scanner = new Scanner(translationLine);
     scanner.useDelimiter("\\[|\\]");
@@ -149,10 +150,6 @@ public class PoParser {
 
     parseTranslationLine(scanner.nextLine(), parts);
 
-    return new Pair<SoyMsgPluralCaseSpec, List<SoyMsgPart>>(caseSpec, parts);
-
+    return new Pair<SoyMsgPluralCaseSpec, ImmutableList<SoyMsgPart>>(caseSpec, ImmutableList.copyOf(parts));
   }
-
-
-
 }

--- a/java/src/com/google/template/soy/sharedpasses/render/EvalVisitor.java
+++ b/java/src/com/google/template/soy/sharedpasses/render/EvalVisitor.java
@@ -374,9 +374,11 @@ public class EvalVisitor extends AbstractReturningExprNodeVisitor<SoyValue> {
         // Bail out if base expression failed a null-safety check.
         return value;
       } else {
-        // This behavior is not ideal, but needed for compatibility with existing code.
-        // TODO: If feasible, find and fix existing instances, then throw RenderException here.
-        return UndefinedData.INSTANCE;
+        // PATCH(robfig): Throw RenderException due to non-nullsafe access on null.
+        throw new RenderException(String.format(
+              "While evaluating \"%s\", encountered null just before accessing \"%s\".",
+              dataAccess.toSourceString(),
+              dataAccess.getSourceStringSuffix()));
       }
     } else if (dataAccess.getType() != null &&
         value != null &&


### PR DESCRIPTION
This is not ready to merge, but it's enough to discuss.

The idea is that the following workflow would be supported for gettext / PO files
- Extract messages to a .pot file using SoyMsgExtractor (either a different main class or it could be integrated with a command line flag)
- Developer uses standard tools to instantiate the per-locale .po files from the .pot file, using the msginit tool or an online service
- Create a SoyMsgBundle using a .po file.  The calling code can arrange that the right one is used.

gettext supports a limited set of functionality:
- If Plural is used, it must be the only child of the Msg node.  It must have exactly two cases: {case 1}, {default}.
- Select is not supported

Given the long history of gettext, I think that these restrictions are not too restrictive in practice. 

Things that would need to be done:
- Documentation for how to use it and the limitations when using PO format.  Also, documentation for the plural tag.
- Clean up the code - it was mostly taken from a patchset that was linked from the mailing list a couple years ago 
- Test the PoGenerator - internally, we use the message extractor from the Go soy library to generate PO files, rather than the one in this changeset.  I'm not sure if we've tested it..
- Unit tests would probably be nice

What are thoughts? 