### PR TITLE
Unescape percent-encoded spaces in paths

### DIFF
--- a/java/src/com/google/template/soy/base/internal/SoyFileSupplier.java
+++ b/java/src/com/google/template/soy/base/internal/SoyFileSupplier.java
@@ -138,7 +138,9 @@ public interface SoyFileSupplier {
       if (inputFileUrl.getProtocol().equals("file")) {
         // If the URL corresponds to a local file (such as a resource during local development),
         // open it up as a volatile file, so we can account for changes to the file.
-        return new VolatileSoyFileSupplier(new File(inputFileUrl.getPath()), soyFileKind);
+	// But first unescape space characters...
+        String filename = inputFileUrl.getFile().replace("%20", " ");
+        return new VolatileSoyFileSupplier(new File(filename), soyFileKind);
       } else {
         return create(
             Resources.asCharSource(inputFileUrl, UTF_8), soyFileKind, filePath);


### PR DESCRIPTION
Failure to do so causes the tests to fail if there is a space in the path to the directory containing the Closure Templates compiler.

(I have a CLA.)