### PR TITLE
downgrade maven-compiler-plugin to 3.1 to fix its annotation bugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,10 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.2</version>
+        <!-- this is downgraded from 3.2 or 3.3 until maven corrects its annotation compiler code.
+             See https://issues.apache.org/jira/browse/MCOMPILER-235 and
+             https://issues.apache.org/jira/browse/MCOMPILER-236 -->
+        <version>3.1</version>
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>


### PR DESCRIPTION
maven-compiler-plugin 3.2 and 3.3 has a bug where classes created by annotations (e.g. classes made by AutoValue) will turn up in duplicate class errors on the second compile of the repo. Running `mvn clean compile` works, but running `mvn compile` a second time does not.

There are two workarounds: 1) downgrading to 3.1; 2) adding `<useIncrementalCompilation>false</useIncrementalComplication>`

Unfortunately and confusingly, option 2 turns on maven's incremental compilation, not off. This incremental compilation has a notorious history of being inaccurate.

Given the choice of requiring continuous cleaning, breaking builds sometimes, and downgrading, downgrading seems the best choice.

See https://issues.apache.org/jira/browse/MCOMPILER-235 and https://issues.apache.org/jira/browse/MCOMPILER-236 for more.

Fixes #46