### PR TITLE
remove unneeded Predicate in ContextualAutoescaper

### DIFF
--- a/java/src/com/google/template/soy/parsepasses/contextautoesc/ContextualAutoescaper.java
+++ b/java/src/com/google/template/soy/parsepasses/contextautoesc/ContextualAutoescaper.java
@@ -172,9 +172,9 @@ public final class ContextualAutoescaper {
     // all contextual templates, and will not barf on private templates that might be declared
     // autoescape="false" because they do funky things that are provably safe by human reason but
     // not by this algorithm.
-    Set<TemplateNode> templateNodesToType = callGraph.callersOf(
-        Collections2.filter(allTemplates, IS_CONTEXTUAL));
-    templateNodesToType.addAll(Collections2.filter(allTemplates, REQUIRES_INFERENCE));
+    Collection<TemplateNode> inferTemplates = Collections2.filter(allTemplates, REQUIRES_INFERENCE);
+    Set<TemplateNode> templateNodesToType = callGraph.callersOf(inferTemplates);
+    templateNodesToType.addAll(inferTemplates);
     Set<SourceLocation> errorLocations = new HashSet<>();
     for (TemplateNode templateNode : templateNodesToType) {
       try {
@@ -312,14 +312,6 @@ public final class ContextualAutoescaper {
     }
     return templatesByNameBuilder.build();
   }
-
-  private static final Predicate<TemplateNode> IS_CONTEXTUAL = new Predicate<TemplateNode>() {
-    @Override
-    public boolean apply(TemplateNode templateNode) {
-      return templateNode.getAutoescapeMode() == AutoescapeMode.CONTEXTUAL
-          || templateNode.getAutoescapeMode() == AutoescapeMode.STRICT;
-    }
-  };
 
   private static final Predicate<TemplateNode> REQUIRES_INFERENCE
       = new Predicate<TemplateNode>() {


### PR DESCRIPTION
The REQUIRES_INFERENCE and IS_CONTEXTUAL Predicates in ContextualAutoescaper are equivalent. We remove IS_CONTEXTUAL since REQUIRES_INFERENCE has a comment and less misleading (but more opaque) name.