### PR TITLE
Upgraded Guice to 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.7</java.version>
-    <guice.version>3.0</guice.version>
+    <guice.version>4.0</guice.version>
     <guava.version>17.0</guava.version>
     <asm.version>5.0.3</asm.version>
     <autovalue.version>1.0</autovalue.version>
@@ -78,6 +78,12 @@
       <artifactId>guice</artifactId>
       <version>${guice.version}</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Updated ```pom.xml``` to use Guice 4.0. This change was made according to #56.
Because Guice 4.0 comes with the older version of Guava, the dependency for the old version is excluded.