### PR TITLE
correct the execution order for the enforcer plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -355,48 +355,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
-        <executions>
-          <execution>
-            <id>enforce-files-exist</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <phase>verify</phase>
-            <configuration>
-              <rules>
-                <requireFilesExist>
-                  <files>
-                    <file>${soy.examples.out}/simple_generated.js</file>
-                    <file>${soy.examples.out}/simple_generated_en.js</file>
-                    <file>${soy.examples.out}/features_generated_en.js</file>
-                    <file>${soy.examples.out}/simple_generated_x-zz.js</file>
-                    <file>${soy.examples.out}/features_generated_x-zz.js</file>
-                    <file>${soy.examples.out}/FeaturesSoyInfo.java</file>
-                    <file>${soy.examples.out}/examples_extracted.xlf</file>
-                  </files>
-                </requireFilesExist>
-              </rules>
-              <fail>true</fail>
-            </configuration>
-          </execution>
-          <execution>
-            <id>enforce</id>
-            <configuration>
-              <rules>
-                <DependencyConvergence/>
-              </rules>
-              <fail>true</fail>
-            </configuration>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
@@ -668,6 +626,48 @@
             </configuration>
             <goals>
               <goal>exec</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.3.1</version>
+        <executions>
+          <execution>
+            <id>enforce-files-exist</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>verify</phase>
+            <configuration>
+              <rules>
+                <requireFilesExist>
+                  <files>
+                    <file>${soy.examples.out}/simple_generated.js</file>
+                    <file>${soy.examples.out}/simple_generated_en.js</file>
+                    <file>${soy.examples.out}/features_generated_en.js</file>
+                    <file>${soy.examples.out}/simple_generated_x-zz.js</file>
+                    <file>${soy.examples.out}/features_generated_x-zz.js</file>
+                    <file>${soy.examples.out}/FeaturesSoyInfo.java</file>
+                    <file>${soy.examples.out}/examples_extracted.xlf</file>
+                  </files>
+                </requireFilesExist>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <rules>
+                <DependencyConvergence/>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+            <goals>
+              <goal>enforce</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
The `exec-maven-plugin` generates files that are validated in `maven-enforcer-plugin`. The `maven-enforcer-plugin` is currently executed first, failing the build. This commit corrects the execution order, `exec` before `enforcer`. Tested on Apache Maven 3.1.1

```
...
[INFO] --- maven-enforcer-plugin:1.3.1:enforce (enforce-files-exist) @ soy ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireFilesExist failed with message:
Some required files are missing:
/Users/nathancomstock/github/closure-templates/target/examples/simple_generated.js
/Users/nathancomstock/github/closure-templates/target/examples/simple_generated_en.js
/Users/nathancomstock/github/closure-templates/target/examples/features_generated_en.js
/Users/nathancomstock/github/closure-templates/target/examples/simple_generated_x-zz.js
/Users/nathancomstock/github/closure-templates/target/examples/features_generated_x-zz.js
/Users/nathancomstock/github/closure-templates/target/examples/FeaturesSoyInfo.java
/Users/nathancomstock/github/closure-templates/target/examples/examples_extracted.xlf

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 1:14.637s
```
