### PR TITLE
Created package.json for npm integration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk8
+  - oraclejdk8
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk7
+  - openjdk8
 
 sudo: false
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "closure-templates",
+  "version": "1.0.0",
+  "description": "Closure Templates are a client- and server-side templating system that helps you dynamically build reusable HTML and UI elements.",
+  "private": true,
+  "keywords": ["closure", "templates"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/google/closure-templates.git"
+  },
+  "bugs": {
+    "url": "https://github.com/google/closure-templates/issues"
+  },
+  "homepage": "https://developers.google.com/closure/templates/",
+  "author": {
+    "name": "Soy template authors"
+  },
+  "license": "Apache-2.0",
+  "scripts": {
+    "version-update": "npm version patch"
+  },
+  "files": [
+    "CONTRIBUTING",
+    "COPYING",
+    "README.md",
+    "examples/",
+    "javascript/"
+  ]
+}


### PR DESCRIPTION
This package.json file enables the latest "closure-templates" as dependencies for npm.

Example:
```
"dependencies": {
   "closure-templates": "https://github.com/google/closure-templates/tarball/master",
}
```

NPM will automatically fetch the dependency from GitHub so that it will be available under "node_modules/closure-templates/...".
The package.json is marked with "private": true, which mean that it is blocked for uploading to the npm repro.