### PR TITLE
Fixed #80 - Change java.version to 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>1.8</java.version>
+    <java.version>1.7</java.version>
     <guice.version>3.0</guice.version>
     <guava.version>17.0</guava.version>
     <asm.version>5.0.3</asm.version>


### PR DESCRIPTION
This PR fixes #80 and makes it possible for an application running in a Java 7 environment to link against Soy.

I kindly request that you push a release to Maven once this fix is integrated. This is needed for a Google product.