### PR TITLE
Make mvn package command go significantly faster

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -325,6 +325,23 @@
       </testResource>
     </testResources>
 
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-invoker-plugin</artifactId>
+          <version>1.7</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.1</version>
+        </plugin>
+        <plugin>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.6</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -398,7 +415,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>


### PR DESCRIPTION
You may have noticed that when you run the `mvn package` command, it takes like half an hour to run. This PR fixes that.

This is a trick I learned from @cgruber from Google's Java Core Libraries team. I don't 100% understand why it works. But after making this change, `mvn package` runs in only 57 seconds!