### PR TITLE
Favor syntax error over IllegalStateException for duplicate name.

### DIFF
--- a/java/src/com/google/template/soy/parsepasses/contextautoesc/Rewriter.java
+++ b/java/src/com/google/template/soy/parsepasses/contextautoesc/Rewriter.java
@@ -34,6 +34,7 @@ import com.google.template.soy.soytree.SoyFileSetNode;
 import com.google.template.soy.soytree.SoyNode;
 import com.google.template.soy.soytree.SoyNode.ParentSoyNode;
 import com.google.template.soy.soytree.SoyNode.StandaloneNode;
+import com.google.template.soy.soytree.SoySyntaxExceptionUtils;
 import com.google.template.soy.soytree.TemplateNode;
 
 import java.util.List;
@@ -102,7 +103,11 @@ final class Rewriter {
      * Keep track of template nodes so we know which are derived and which aren't.
      */
     @Override protected void visitTemplateNode(TemplateNode templateNode) {
-      Preconditions.checkState(!visitedTemplateNames.contains(templateNode.getTemplateName()));
+      if (visitedTemplateNames.contains(templateNode.getTemplateName())) {
+        throw SoySyntaxExceptionUtils.createWithNode(
+            "was defined previously",
+            templateNode);
+      }
       visitedTemplateNames.add(templateNode.getTemplateName());
       visitChildrenAllowingConcurrentModification(templateNode);
     }


### PR DESCRIPTION
It seems to me that having a duplicate definition of a template is more a
syntax error than an illegal state.  It would be nice to communicate this
back to the template creator in the form of a SoySyntaxException which
will at least point them to the duplicate template definition.

I should mention that I encountered this bug in a template with the following (not sure if that is relevant to the issue):

autoescape="deprecated-noncontextual"

Thank you for considering this pull request.

Sincerely,
Rick