### PR TITLE
bump maven-compiler-plugin to 3.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.5.1</version>
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>


### PR DESCRIPTION
Fixes #46

The maven-compiler-plugin at version 3.2 and 3.3 had a bug that would
cause the annotation generated classes (e.g. classes made by
`@AutoValue`) to be duplicated on the second run of a `mvn compile`.

This fixes that. The relevant maven ticket was https://issues.apache.org/jira/browse/MCOMPILER-235