### PR TITLE
fix the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: java
+
 jdk:
-  - openjdk7
+  - oraclejdk8
+
+cache:
+  - apt
+  - directories:
+      - $HOME/.m2
 
 sudo: false
 

--- a/pom.xml
+++ b/pom.xml
@@ -398,7 +398,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.3</version>
+        <version>3.5.1</version>
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -355,48 +355,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
-        <executions>
-          <execution>
-            <id>enforce-files-exist</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <phase>verify</phase>
-            <configuration>
-              <rules>
-                <requireFilesExist>
-                  <files>
-                    <file>${soy.examples.out}/simple_generated.js</file>
-                    <file>${soy.examples.out}/simple_generated_en.js</file>
-                    <file>${soy.examples.out}/features_generated_en.js</file>
-                    <file>${soy.examples.out}/simple_generated_x-zz.js</file>
-                    <file>${soy.examples.out}/features_generated_x-zz.js</file>
-                    <file>${soy.examples.out}/FeaturesSoyInfo.java</file>
-                    <file>${soy.examples.out}/examples_extracted.xlf</file>
-                  </files>
-                </requireFilesExist>
-              </rules>
-              <fail>true</fail>
-            </configuration>
-          </execution>
-          <execution>
-            <id>enforce</id>
-            <configuration>
-              <rules>
-                <DependencyConvergence/>
-              </rules>
-              <fail>true</fail>
-            </configuration>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.5.1</version>
         <configuration>
@@ -668,6 +626,48 @@
             </configuration>
             <goals>
               <goal>exec</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+            <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>1.3.1</version>
+        <executions>
+          <execution>
+            <id>enforce-files-exist</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <phase>verify</phase>
+            <configuration>
+              <rules>
+                <requireFilesExist>
+                  <files>
+                    <file>${soy.examples.out}/simple_generated.js</file>
+                    <file>${soy.examples.out}/simple_generated_en.js</file>
+                    <file>${soy.examples.out}/features_generated_en.js</file>
+                    <file>${soy.examples.out}/simple_generated_x-zz.js</file>
+                    <file>${soy.examples.out}/features_generated_x-zz.js</file>
+                    <file>${soy.examples.out}/FeaturesSoyInfo.java</file>
+                    <file>${soy.examples.out}/examples_extracted.xlf</file>
+                  </files>
+                </requireFilesExist>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+          <execution>
+            <id>enforce</id>
+            <configuration>
+              <rules>
+                <DependencyConvergence/>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+            <goals>
+              <goal>enforce</goal>
             </goals>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -630,7 +630,7 @@
           </execution>
         </executions>
       </plugin>
-            <plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>1.3.1</version>


### PR DESCRIPTION
mvn install fails locally and in travis with this, but it gets the build closer.  I'll need the closure team's help to figure out the rest.

After the changes discussed below, we get down to the Enforcer plugin isn't able to find files in target/examples directory and there are suspicious looking Soy errors in the test logs.

I'm at a loss.

What's been done so far:

  * bump the .travis.yml JVM to JDK8 closure-template's pom.xml requires JDK8 (see the "1.8" in it).
    Unfortunately, OpenJDK 8 is not supported on TravisCI yet, so we have to switch to the Oracle JDK.

  * fix #46, the maven-compiler-plugin bug, by bumping to a working version of maven-compiler-plugin.

The build failures on this PR are the bug left to be fixed before the build goes green.