### PR TITLE
Upgraded Guice to 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
-    <guice.version>3.0</guice.version>
+    <guice.version>4.0</guice.version>
     <guava.version>17.0</guava.version>
     <asm.version>5.0.3</asm.version>
     <autovalue.version>1.0</autovalue.version>
@@ -87,6 +87,12 @@
       <artifactId>guice</artifactId>
       <version>${guice.version}</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Rebased the branch for the pull request #73 .

> Updated ```pom.xml``` to use Guice 4.0. This change was made according to #56.
Because Guice 4.0 comes with the older version of Guava, the dependency for the old version is excluded.