### PR TITLE
LetValueNode does not return correct toSourceString() value

### DIFF
--- a/java/src/com/google/template/soy/soytree/LetValueNode.java
+++ b/java/src/com/google/template/soy/soytree/LetValueNode.java
@@ -101,6 +101,11 @@ public final class LetValueNode extends LetNode implements ExprHolderNode {
     return new LetValueNode(this, copyState);
   }
 
+  @Override
+  public String getTagString() {
+    return this.buildTagStringHelper(true);
+  }
+
   /**
    * Builder for {@link LetValueNode}.
    */
@@ -150,4 +155,5 @@ public final class LetValueNode extends LetNode implements ExprHolderNode {
           id, sourceLocation, parseResult.localVarName, commandText, parseResult.valueExpr);
     }
   }
+
 }


### PR DESCRIPTION
Let value node does not return a self ending source string. This is an issue when trying to print the a soy file set back to soy files. 