### PR TITLE
fixing issue #102

### DIFF
--- a/java/src/com/google/template/soy/soytree/RawTextNode.java
+++ b/java/src/com/google/template/soy/soytree/RawTextNode.java
@@ -38,13 +38,15 @@ public final class RawTextNode extends AbstractSoyNode implements StandaloneNode
 
 
   /** The special chars we need to re-escape for toSourceString(). */
-  private static final Pattern SPECIAL_CHARS_TO_ESCAPE = Pattern.compile("[\n\r\t{}]");
+  private static final Pattern SPECIAL_CHARS_TO_ESCAPE = Pattern.compile("([\n\r\t{}]|/\\*\\*|\\*/)");
 
   /** Map from special char to be re-escaped to its special char tag (for toSourceString()). */
   private static final Map<String, String> SPECIAL_CHAR_TO_TAG =
       ImmutableMap.<String, String>builder()
           .put("\n", "{\\n}").put("\r", "{\\r}").put("\t", "{\\t}")
           .put("{", "{lb}").put("}", "{rb}")
+          .put("/**", "{literal}/**{/literal}")
+          .put("*/", "{literal}*/{/literal}")
           .build();
 
 

--- a/java/tests/com/google/template/soy/soytree/RawTextNodeTest.java
+++ b/java/tests/com/google/template/soy/soytree/RawTextNodeTest.java
@@ -28,7 +28,12 @@ import junit.framework.*;
 public final class RawTextNodeTest extends TestCase {
 
   public void testToSourceString() {
-    RawTextNode rtn = new RawTextNode(0, "Aa`! \n \r \t { }", SourceLocation.UNKNOWN);
-    assertEquals("Aa`! {\\n} {\\r} {\\t} {lb} {rb}", rtn.toSourceString());
+    assertEquals("Aa`! {\\n} {\\r} {\\t} {lb} {rb}", rawTextToSourceString("Aa`! \n \r \t { }"));
+    assertEquals("{literal}/**{/literal} some comment {literal}*/{/literal}",  rawTextToSourceString("/** some comment */"));
+    assertEquals("{literal}/**{/literal}* some comment {literal}*/{/literal}",  rawTextToSourceString("/*** some comment */"));
+  }
+
+  private String rawTextToSourceString(final String rawText) {
+    return new RawTextNode(0, rawText, SourceLocation.UNKNOWN).toSourceString();
   }
 }


### PR DESCRIPTION
This escapes `/**` and `*/` text in rawTextNode back into {literal} tags

Fixes:  #102