### PR TITLE
SoyMsgExtractor: Handle errors instead of succeeding quietly

### DIFF
--- a/java/src/com/google/template/soy/SoyFileSet.java
+++ b/java/src/com/google/template/soy/SoyFileSet.java
@@ -712,8 +712,7 @@ public final class SoyFileSet {
                 soyFunctionMap)
             .fileSet();
     SoyMsgBundle bundle = new ExtractMsgsVisitor().exec(soyTree);
-    // TODO(lukes): this should call throwIfErrorsPresent(), but can't because it will break
-    // build rules.
+    throwIfErrorsPresent();
     return bundle;
   }
 


### PR DESCRIPTION
Fixes https://github.com/google/closure-templates/issues/121

it seems like if there's some internal google reason that you can't report errors here, it'd be better to have some sort of --ignore_errors flag