### PR TITLE
Bump args4j version to 2.33

### DIFF
--- a/java/src/com/google/template/soy/AbstractSoyCompiler.java
+++ b/java/src/com/google/template/soy/AbstractSoyCompiler.java
@@ -124,7 +124,7 @@ abstract class AbstractSoyCompiler {
             + "access support for proto types.",
     handler = SoyCmdLineParser.FileListOptionHandler.class
   )
-  private final List<File> protoFileDescriptors = new ArrayList<>();
+  private List<File> protoFileDescriptors = new ArrayList<>();
 
   @Option(
     name = "--conformanceConfig",
@@ -147,7 +147,7 @@ abstract class AbstractSoyCompiler {
             + "experiments on. Please proceed with caution at your own risk.",
     handler = SoyCmdLineParser.StringListOptionHandler.class
   )
-  private final List<String> experimentalFeatures = new ArrayList<>();
+  private List<String> experimentalFeatures = new ArrayList<>();
 
   @Option(
     name = "--disableOptimizerForTestingUseOnly",
@@ -159,7 +159,7 @@ abstract class AbstractSoyCompiler {
   private boolean disableOptimizer = false;
 
   /** The remaining arguments after parsing command-line flags. */
-  @Argument private final List<String> arguments = new ArrayList<>();
+  @Argument private List<String> arguments = new ArrayList<>();
 
   final ClassLoader pluginClassLoader;
 

--- a/pom.xml
+++ b/pom.xml
@@ -257,7 +257,7 @@
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
-      <version>2.0.23</version>
+      <version>2.33</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
Final modifier is not allowed by new args4j version any more, due to
this validation: [1].

Test Plan:

  $ mvn package

[1] https://github.com/kohsuke/args4j/commit/6e11f89d40dcc518c0e5eb9eef5d74f05d58e6af