### PR TITLE
Update MapKeysFunction javadoc with latest for-loop syntax

### DIFF
--- a/java/src/com/google/template/soy/basicfunctions/MapKeysFunction.java
+++ b/java/src/com/google/template/soy/basicfunctions/MapKeysFunction.java
@@ -45,8 +45,8 @@ import javax.inject.Singleton;
  * <p>The keys are returned as a list with no guarantees on the order (may be different on each run
  * or for each backend).
  *
- * <p>This enables iteration over the keys in a map, e.g. {@code {foreach $key in keys($myMap)} ...
- * {/foreach}}
+ * <p>This enables iteration over the keys in a map, e.g. {@code {for $key in keys($myMap)} ...
+ * {/for}}
  *
  * <p>NOTE: this function has special support in the type checker for calculating the return type
  *


### PR DESCRIPTION
ecf9a5cf2f62cf88099c774041e60e29e1ae1c04 removed `{foreach}` loops