### PR TITLE
Change error-prone maven dependency scope to compile (default)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,8 +188,6 @@
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
       <version>2.0.14</version>
-      <!-- unnecessary at runtime since retention of annotations is CLASS -->
-      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
`SoyTemplateInfo` has the `@Immutable` annotation which has `RUNTIME` retention. 

Before this change, it wasn't possible to compile the files generated by `SoyParseInfoGenerator` with an annotation-processor like [AutoValue](https://github.com/google/auto/tree/master/value) or `https://github.com/inferred/FreeBuilder` on the classpath. The call to `RoundEnvironment#getElementsAnnotatedWith` fails with 

```
error: cannot access Immutable
  class file for com.google.errorprone.annotations.Immutable not found
1 error
```

Fixes #147.

Before this change, using Maven to compile generated `SoyTemplateInfo` classes with an annotation processor on the classpath was only possible by adding `error_prone_annotations` as an explicit dependency:

```xml
<dependency>
  <groupId>com.google.errorprone</groupId>
  <artifactId>error_prone_annotations</artifactId>
  <version>2.0.12</version>
</dependency>
```