### PR TITLE
Fix: Add 'main' method to SoyHeaderCompiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 sudo: false
 

--- a/java/src/com/google/template/soy/SoyHeaderCompiler.java
+++ b/java/src/com/google/template/soy/SoyHeaderCompiler.java
@@ -60,4 +60,15 @@ final class SoyHeaderCompiler extends AbstractSoyCompiler {
       unit.writeTo(os);
     }
   }
+
+  /**
+   * Compiles a set of Soy files into corresponding header files, which are usable as intermediates
+   * for future Soy compile routines.
+   *
+   * @param args Should contain command-line flags and the list of paths to the Soy files.
+   * @throws IOException If there are problems reading the input files or writing the output file.
+   */
+  public static void main(final String[] args) throws IOException {
+    new SoyHeaderCompiler().runMain(args);
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -609,6 +609,23 @@
             </configuration>
           </execution>
           <execution>
+            <id>SoyHeaderCompiler</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>SoyHeaderCompiler</shadedClassifierName>
+              <transformers>
+                <transformer
+                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>com.google.template.soy.SoyHeaderCompiler</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+          <execution>
             <id>SoyToPySrcCompiler</id>
             <phase>package</phase>
             <goals>


### PR DESCRIPTION
The `SoyHeaderCompiler` class is not currently callable via the command line, like the other compilers. This changeset makes that possible with a `main` method and a few other tweaks.

Changes so far:
- [x] Add `main` method to `SoyHeaderCompiler` class
- [x] Add Maven shade/package execution for header compiler