### PR TITLE
Fix: TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 sudo: false
 


### PR DESCRIPTION
Oracle JDK 8 no longer works properly with the image specified in TravisCI. This change simply switches to OpenJDK 8.