### PR TITLE
Fix: Soy VELog use of `xid`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 sudo: false
 

--- a/javascript/soyutils_velog.js
+++ b/javascript/soyutils_velog.js
@@ -29,10 +29,24 @@ goog.module('soy.velog');
 goog.module.declareLegacyNamespace();
 
 const Message = goog.require('jspb.Message');
-const xid = goog.require('xid');
 const {assert} = goog.require('goog.asserts');
 const {getFirstElementChild, getNextElementSibling} = goog.require('goog.dom');
 const {startsWith} = goog.require('goog.string');
+
+
+/**
+ * ID generator for soy operations.
+ *
+ * @idGenerator {xid}
+ * @param {!string} id Un-rewritten ID to use.
+ * @return {!string} ID to use in code (potentially rewritten).
+ */
+function xidGen(id) {
+  return id;
+}
+
+exports.xid = xidGen;
+
 
 /** @final */
 class ElementMetadata {
@@ -92,10 +106,10 @@ class Metadata {
 // NOTE: we need to use toLowerCase in case the xid contains upper case
 // characters, browsers normalize keys to their ascii lowercase versions when
 // accessing attributes via the programmatic APIs (as we do below).
-/** @package */ const ELEMENT_ATTR = 'data-' + xid('soylog').toLowerCase();
+/** @package */ const ELEMENT_ATTR = 'data-' + xidGen('soylog').toLowerCase();
 
 /** @package */ const FUNCTION_ATTR =
-    'data-' + xid('soyloggingfunction').toLowerCase() + '-';
+    'data-' + xidGen('soyloggingfunction').toLowerCase() + '-';
 
 /** Sets up the global metadata object before rendering any templates. */
 function setUpLogging() {


### PR DESCRIPTION
When building Soy using Closure Compiler (OSS), the `soyutils_velog.js` package can cause issues with its use of `xid`, which may be a module, which makes it unable to be called as a function.

This is likely a side effect of the transition to `@idGenerator`-based `xid` functions.

In any case, installing an `xid` function into the `soyutil_velog` solves the issue. This changeset does that.

_NOTE:_ this changeset has had the Travis CI fix cherry-picked onto it, to facilitate testing for this change in CI (see #181 for the Travis fix).