### PR TITLE
Fix: SoyTofu Resolve Template

### DIFF
--- a/java/src/com/google/template/soy/tofu/SoyTofu.java
+++ b/java/src/com/google/template/soy/tofu/SoyTofu.java
@@ -28,6 +28,7 @@ import com.google.template.soy.shared.SoyCssRenamingMap;
 import com.google.template.soy.shared.SoyIdRenamingMap;
 import java.util.Map;
 import java.util.function.Predicate;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -53,6 +54,15 @@ public interface SoyTofu {
    * @return The namespace of this SoyTofu object, or null if no namespace.
    */
   String getNamespace();
+
+  /**
+   * Queries the current SoyTofu instance to see if it holds a given template. If the requested
+   * template is found, `true` is returned, otherwise, `false`.
+   *
+   * @param namespace Namespace to check for a template.
+   * @return Whether the template exists or not.
+   */
+  Boolean hasTemplate(@Nonnull String namespace);
 
   /**
    * Gets a new SoyTofu instance with a different namespace (or no namespace). Note: The new SoyTofu

--- a/java/src/com/google/template/soy/tofu/internal/BaseTofu.java
+++ b/java/src/com/google/template/soy/tofu/internal/BaseTofu.java
@@ -59,6 +59,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -180,6 +181,18 @@ public final class BaseTofu implements SoyTofu {
   @Override
   public String getNamespace() {
     return null;
+  }
+
+  /**
+   * Queries the current SoyTofu instance to see if it holds a given template. If the requested
+   * template is found, `true` is returned, otherwise, `false`.
+   *
+   * @param namespace Namespace to check for a template.
+   * @return Whether the template exists or not.
+   */
+  @Override
+  public Boolean hasTemplate(@Nonnull String namespace) {
+    return this.basicTemplates.containsKey(namespace);
   }
 
   @Override

--- a/java/src/com/google/template/soy/tofu/internal/NamespacedTofu.java
+++ b/java/src/com/google/template/soy/tofu/internal/NamespacedTofu.java
@@ -25,6 +25,7 @@ import com.google.template.soy.msgs.SoyMsgBundle;
 import com.google.template.soy.parseinfo.SoyTemplateInfo;
 import com.google.template.soy.tofu.SoyTofu;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -60,6 +61,18 @@ public final class NamespacedTofu implements SoyTofu {
   @Override
   public String getNamespace() {
     return namespace;
+  }
+
+  /**
+   * Queries the current SoyTofu instance to see if it holds a given template. If the requested
+   * template is found, `true` is returned, otherwise, `false`.
+   *
+   * @param namespace Namespace to check for a template.
+   * @return Whether the template exists or not.
+   */
+  @Override
+  public Boolean hasTemplate(@Nonnull String namespace) {
+    return baseTofu.hasTemplate(namespace);
   }
 
   @Override

--- a/java/tests/com/google/template/soy/tofu/internal/TofuHasTemplateTest.java
+++ b/java/tests/com/google/template/soy/tofu/internal/TofuHasTemplateTest.java
@@ -1,0 +1,47 @@
+package com.google.template.soy.tofu.internal;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.template.soy.SoyFileSetParserBuilder;
+import com.google.template.soy.shared.internal.NoOpScopedData;
+import com.google.template.soy.tofu.SoyTofu;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import static org.junit.Assert.*;
+
+
+/** Unit tests for `hasTemplate` method of {@link SoyTofu}. */
+@RunWith(JUnit4.class)
+public class TofuHasTemplateTest {
+  private static final String SOY_FILE =
+    Joiner.on('\n')
+          .join(
+            "{namespace sample}",
+            "",
+            "/** */",
+            "{template .example}",
+            "  hello world",
+            "{/template}");
+
+  private SoyTofu tofu;
+
+  @Before
+  public void setUp() throws Exception {
+    tofu =
+      new BaseTofu(
+        new NoOpScopedData(),
+        SoyFileSetParserBuilder.forFileContents(SOY_FILE).parse().fileSet(),
+        ImmutableMap.of());
+  }
+
+  @Test
+  public void testHasTemplate() throws Exception {
+    assertTrue("SoyTofu should report `true` for `hasTemplate` call with valid template",
+      tofu.hasTemplate("sample.example"));
+    assertFalse("SoyTofu should report `false` for `hasTemplate` call with unrecognized template",
+      tofu.hasTemplate("some.unrecognized.path"));
+  }
+}


### PR DESCRIPTION
This patch adds a method to `SoyTofu` to query whether a given instance holds a template namespace. This change is needed for compatibility with frameworks downstream (some frameworks check for a template before rendering).

I'm aware `SoyTofu` is deprecated, but it is still the easiest path to server-side templates for OSS users. Next up is a similar implementation for `SoySauce`.

Thank you in advance for considering this change. While `SoyTofu` is in the rear-view, it would really help our systems work together with Soy in Java.

Changes:
- [x] Add method to `SoyTofu` interface to query for a template namespace
- [x] Add implementation of new method to `BaseTofu`
- [x] Add tests for new method (`hasTemplate` on `SoyTofu`)