### PR TITLE
Fix: SoySauce Resolve Template

### DIFF
--- a/java/src/com/google/template/soy/jbcsrc/api/SoySauce.java
+++ b/java/src/com/google/template/soy/jbcsrc/api/SoySauce.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.function.Predicate;
 import javax.annotation.CheckReturnValue;
+import javax.annotation.Nonnull;
 
 /**
  * Main entry point for rendering Soy templates on the server.
@@ -47,6 +48,13 @@ public interface SoySauce {
   default Renderer newRenderer(TemplateParameters params) {
     return renderTemplate(params.getTemplateName()).setData(params.getParamsAsMap());
   }
+
+  /**
+   * Indicates whether the current {@link SoySauce} instance holds a given template.
+   *
+   * @return `true` if the template is valid, `false` if it is unrecognized.
+   */
+  Boolean hasTemplate(@Nonnull String template);
 
   /**
    * Returns the transitive set of {@code $ij} params needed to render this template.

--- a/java/src/com/google/template/soy/jbcsrc/api/SoySauceImpl.java
+++ b/java/src/com/google/template/soy/jbcsrc/api/SoySauceImpl.java
@@ -54,6 +54,7 @@ import com.google.template.soy.shared.restricted.SoyPrintDirective;
 import java.io.IOException;
 import java.util.Map;
 import java.util.function.Predicate;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /** Main entry point for rendering Soy templates on the server. */
@@ -114,6 +115,16 @@ public final class SoySauceImpl implements SoySauce {
   public RendererImpl renderTemplate(String template) {
     CompiledTemplate.Factory factory = templates.getTemplateFactory(template);
     return new RendererImpl(template, factory, templates.getTemplateContentKind(template), null);
+  }
+
+  @Override
+  public Boolean hasTemplate(@Nonnull String template) {
+    try {
+      templates.getTemplateFactory(template);
+      return true;
+    } catch (IllegalArgumentException iae) {
+      return false;
+    }
   }
 
   @Override

--- a/java/tests/com/google/template/soy/jbcsrc/api/SoySauceTest.java
+++ b/java/tests/com/google/template/soy/jbcsrc/api/SoySauceTest.java
@@ -18,8 +18,7 @@ package com.google.template.soy.jbcsrc.api;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.template.soy.data.UnsafeSanitizedContentOrdainer.ordainAsSafe;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.SettableFuture;
@@ -50,6 +49,13 @@ public class SoySauceTest {
     SoyFileSet.Builder builder = SoyFileSet.builder();
     builder.add(SoySauceTest.class.getResource("strict.soy"));
     sauce = builder.build().compileTemplates();
+  }
+
+  /** Verifies SoySauce#hasTemplate(String). */
+  @Test
+  public void testHasTemplate() {
+    assertTrue(sauce.hasTemplate("strict_test.helloHtml"));
+    assertFalse(sauce.hasTemplate("i.do.not.exist"));
   }
 
   /** Verifies SoySauce.Renderer#renderHtml(). */


### PR DESCRIPTION
Similar to the change in google/closure-templates#185, this PR adds a method to `SoySauce` to determine whether a given instance holds a template. This change is used downstream for frameworks that first ask a template engine if a template is available, before rendering.

I'm happy to submit these two changes as one. Like the previous PR, this one comes with unit tests that cover the new functionality.

Changes:
- [x] Add method to `SoySauce` interface, matching the one added in `SoyTofu`, called `hasTemplate(String template);`
- [x] Implement new method in `SoySauceImpl` (best way I saw to do this is what I did, but open to feedback here of course)
- [x] Add unit test for new functionality