### PR TITLE
Add presubmit configuration for BazelCI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,0 +1,21 @@
+---
+platforms:
+  macos:
+    build_targets:
+      - "..."
+
+  rbe_ubuntu1604:
+    build_targets:
+      - "..."
+
+  ubuntu1604:
+    build_targets:
+      - "..."
+
+  ubuntu1804:
+    build_targets:
+      - "..."
+
+  windows:
+    build_targets:
+      - "..."


### PR DESCRIPTION
This change adds the configuration for BazelCI, as described at
`https://github.com/bazelbuild/continuous-integration`.
Note that this also runs on postsubmit.