### PR TITLE
Fix broken links in reference/templates.md document

### DIFF
--- a/documentation/reference/templates.md
+++ b/documentation/reference/templates.md
@@ -50,14 +50,16 @@ These are the `template` tag's attributes:
 <!--#include file="common-attributes-include.md"-->
 
 *   `stricthtml`: Optional. Default `true`. Configures
-    [strict html support](html)
+    [strict html support](html.md)
 
 *   `whitespace`: Optional. Default `join`. Configures the whitespace joining
-    algorithm to use. See the [Line Joining](textual-commands##line-joining)
+    algorithm to use. See the
+    [Line Joining](textual-commands.md#line-joining-line-joining)
     documentation for details on the default `join` algorithm. Set this to
     `preserve` if you want to preserve all whitespace characters that are found
     inside the current template. This behavior is similar to what can be
-    observed when using the [{literal}](textual-commands#literal) command.
+    observed when using the [{literal}](textual-commands.md#literal-literal)
+    command.
 
     For example, consider the following input file:
 
@@ -106,7 +108,7 @@ Syntax:
 `{@param}` declares a template parameter. Parameter declarations must come first
 in the template, preceding all other template content.
 
-See the [types reference](types) for instructions on how to declare types.
+See the [types reference](types.md) for instructions on how to declare types.
 
 ### Required params
 
@@ -133,8 +135,8 @@ The inferred type is `null` but this also allows the parameter to accept
 `string`s.
 
 The default value can only be a compile-time constant expression. It cannot
-reference any other parameters or call [non-pure](../dev/plugins#pure) Soy
-functions.
+reference any other parameters or call
+[non-pure](../dev/plugins.md#pure-functions-pure) Soy functions.
 
 NOTE: Default parameters don't support content kind types like `html`, `uri` or
 `attributes`.
@@ -160,10 +162,10 @@ Syntax:
 ```
 
 `{@inject}` declares an [injected template parameter](../concepts/ij-data.md).
-The syntax is identical to the [required param](#param) syntax with the
+The syntax is identical to the [required param](#param-param) syntax with the
 exception of the keyword.
 
-See the [types reference](types) for instructions on how to declare types.
+See the [types reference](types.md) for instructions on how to declare types.
 
 ## Doc comments for params {#doc-comments}
 
@@ -184,5 +186,5 @@ Example:
 
 ## Parameter type expressions {#param-type}
 
-See the [type expression reference](types) for the types that can appear in a
+See the [type expression reference](types.md) for the types that can appear in a
 parameter declaration.


### PR DESCRIPTION
## Context

Multiple links in the doc are broken and lead to a 404 page.