### PR TITLE
SoyToJbcSrcCompiler --srcs work for both space and comma separated files

### DIFF
--- a/java/src/com/google/template/soy/SoyCmdLineParser.java
+++ b/java/src/com/google/template/soy/SoyCmdLineParser.java
@@ -140,7 +140,7 @@ public final class SoyCmdLineParser extends CmdLineParser {
       String parameter = params.getParameter(0);
       // An empty string should be an empty list, not a list containing the empty item
       if (!parameter.isEmpty()) {
-        for (String item : parameter.split(",")) {
+        for (String item : parameter.split("[\\s,]+")) {
           setter.addValue(parseItem(item));
         }
       }


### PR DESCRIPTION
Bazels genrule $(SRCS) outputs space separated files, which doesn't work for --srcs flag of SoyToJbcSrcCompiler.