### PR TITLE
refactor: refactor bad smell ToArrayCallWithZeroLengthArrayArgument

### DIFF
--- a/java/src/com/google/template/soy/jbcsrc/internal/SoyClassWriter.java
+++ b/java/src/com/google/template/soy/jbcsrc/internal/SoyClassWriter.java
@@ -112,7 +112,7 @@ public final class SoyClassWriter extends ClassVisitor {
         Opcodes.V1_8,
         builder.access,
         builder.type.internalName(),
-        null ,
+        null /* not generic */,
         builder.baseClass.internalName(),
         builder.interfaces.toArray(new String[0]));
     if (builder.fileName != null) {

--- a/java/src/com/google/template/soy/jbcsrc/internal/SoyClassWriter.java
+++ b/java/src/com/google/template/soy/jbcsrc/internal/SoyClassWriter.java
@@ -112,9 +112,9 @@ public final class SoyClassWriter extends ClassVisitor {
         Opcodes.V1_8,
         builder.access,
         builder.type.internalName(),
-        null /* not generic */,
+        null ,
         builder.baseClass.internalName(),
-        builder.interfaces.toArray(new String[builder.interfaces.size()]));
+        builder.interfaces.toArray(new String[0]));
     if (builder.fileName != null) {
       super.visitSource(
           builder.fileName,


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## ToArrayCallWithZeroLengthArrayArgument
The performance of the empty array version is the same, and sometimes even better, compared
to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or
synchronized collection as a data race is possible between the <code>size</code> and <code>toArray</code>
calls. This may result in extra <code>null</code>s at the end of the array if the collection was concurrently
shrunk during the operation.</p>
See https://shipilev.net/blog/2016/arrays-wisdom-ancients/ for more details.

<!-- fingerprint:1951063876 -->
# Repairing Code Style Issues
* ToArrayCallWithZeroLengthArrayArgument (1)
