### PR TITLE
Fix broken docs links missing .md

### DIFF
--- a/documentation/reference/templates.md
+++ b/documentation/reference/templates.md
@@ -53,14 +53,14 @@ These are the `template` tag's attributes:
     autoprefixing in [`css` function](functions.md#css) calls.
 
 *   `stricthtml`: Optional. Default `true`. Configures
-    [strict html support](html)
+    [strict html support](html.md)
 
 *   `whitespace`: Optional. Default `join`. Configures the whitespace joining
-    algorithm to use. See the [Line Joining](textual-commands##line-joining)
+    algorithm to use. See the [Line Joining](textual-commands.md##line-joining)
     documentation for details on the default `join` algorithm. Set this to
     `preserve` if you want to preserve all whitespace characters that are found
     inside the current template. This behavior is similar to what can be
-    observed when using the [{literal}](textual-commands#literal) command.
+    observed when using the [{literal}](textual-commands.md#literal) command.
 
     For example, consider the following input file:
 
@@ -109,7 +109,7 @@ Syntax:
 `{@param}` declares a template parameter. Parameter declarations must come first
 in the template, preceding all other template content.
 
-See the [types reference](types) for instructions on how to declare types.
+See the [types reference](types.md) for instructions on how to declare types.
 
 ### Required params
 
@@ -136,7 +136,7 @@ The inferred type is `null` but this also allows the parameter to accept
 `string`s.
 
 The default value can only be a compile-time constant expression. It cannot
-reference any other parameters or call [non-pure](../dev/plugins#pure) Soy
+reference any other parameters or call [non-pure](../dev/plugins.md#pure) Soy
 functions.
 
 NOTE: Default parameters don't support content kind types like `html`, `uri` or
@@ -166,7 +166,7 @@ Syntax:
 The syntax is identical to the [required param](#param) syntax with the
 exception of the keyword. The injected parameter may be optional (`{@inject?}`).
 
-See the [types reference](types) for instructions on how to declare types.
+See the [types reference](types.md) for instructions on how to declare types.
 
 ## Doc comments for params {#doc-comments}
 
@@ -187,5 +187,5 @@ Example:
 
 ## Parameter type expressions {#param-type}
 
-See the [type expression reference](types) for the types that can appear in a
+See the [type expression reference](types.md) for the types that can appear in a
 parameter declaration.


### PR DESCRIPTION
Was getting 404 errors due to missing `.md` file extensions.

Perhaps the docs are generated to somewhere not requiring the extensions. If so, feel free to disregard :)