### PR TITLE
Align POM with previously made Bazel changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,12 +77,12 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>17</java.version>
+    <java.version>21</java.version>
     <guice.version>7.0.0</guice.version>
-    <guava.version>32.1.1-jre</guava.version>
+    <guava.version>33.0.0-jre</guava.version>
     <asm.version>9.5</asm.version>
     <autovalue.version>1.11.0</autovalue.version>
-    <proto.version>3.21.7</proto.version>
+    <proto.version>4.34.1</proto.version>
     <truth.version>1.4.0</truth.version>
     <flogger.version>0.7.4</flogger.version>
     <soy.examples.path>examples</soy.examples.path>


### PR DESCRIPTION
Bazel was updated to use Java 21 and a more modern version of Protobuf and Guava in commit 03685e234c8575e8a12d8163c4866485278a955b. However the Maven POM was not updated to reflect this. Hence these changes to align the Maven POM with the changes made to the Bazel build.