### PR TITLE
Fix Python buildStyleValue to filter colon-less CSS values

### DIFF
--- a/python/runtime.py
+++ b/python/runtime.py
@@ -794,7 +794,7 @@ def build_style_value(*values):
 
 def filter_style_part(part):
   """filters each css declaration."""
-  if isinstance(part, str) and part.find(':') != 1:
+  if isinstance(part, str) and part.find(':') != -1:
     name, value = part.split(':', 1)
     if re.search(r'^\s*[\w-]+\s*$', name):
       return (


### PR DESCRIPTION
## Problem

`python/runtime.py` `filter_style_part()` (called by `build_style_value()`, which the Soy Python backend emits for the `buildStyleValue` function) tests for a colon with:

```python
if isinstance(part, str) and part.find(':') != 1:
    name, value = part.split(':', 1)
```

`part.find(':') != 1` is false only when the colon is the *second* character. This causes two bugs:

1. **Crash on colon-less values.** A raw string CSS value with no colon (e.g. `"red"`, `"none"`, `"10px"` — legal inputs since the JS backend documents raw strings as CSS values, and sanitized CSS values pass through as values) hits `part.split(':', 1)` which returns a single-element list, so `name, value = ...` raises `ValueError: not enough values to unpack`.
2. **Unfiltered single-character property names.** A declaration like `a:b` skips name validation and `filter_css_value`, diverging from the intended behavior.

## Fix

Change the check to `!= -1`, matching the JavaScript reference implementation `$$buildStyleValue` in `javascript/soyutils_usegoog.js`, which uses `firstColonPos != -1` and falls back to filtering the whole value when no colon is present.

## Verification

Reproduced locally against the current module:
- before: `filter_style_part('red')` -> `ValueError: not enough values to unpack (expected 2, got 1)`
- after: `filter_style_part('red')` -> `'red'`; `filter_style_part('a:b')` -> `'a:b'`; `build_style_value('red', 'color: green')` -> `SanitizedCss`

Signed-off-by: rootkiller6788